### PR TITLE
Upgrade to HIA v24.07

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -15,11 +15,22 @@ env:
   # When using "Q&A"s, you can enable search: (set to 'true' / 'false')
   NG_USE_Q_AND_A_SEARCH: 'true'
   #
-  # Use the language-switcher to switch between Regions (set to 'true' / 'false')
-  NG_USE_REGION_PER_LOCALE: 'true'
-  #
   # Enable Feedback-prompt on Sub-Category and Offer pages (set to 'true' / 'false')
   NG_USE_FEEDBACK_PROMPT: 'false'
+  #
+  # Use the language-switcher to switch between Regions (set to 'true' / 'false')
+  NG_USE_REGION_PER_LOCALE: 'false'
+  #
+  # Default language
+  NG_LOCALE_LANGUAGE: 'en'
+  # Default language direction (Possible values: 'ltr' or 'rtl')
+  NG_LOCALE_DIR: 'ltr'
+  # Available language options (Comma-separated list like: '<language-code>:<language-name>,ar:العربية,en:English,*:Other...')
+  # To disable the language-switcher on the main-page, or when using `NG_USE_REGION_PER_LOCALE=true`, set this to: ''
+  NG_LOCALE_ALTERNATIVES: ''
+  # An (optional) explanation below the list of available language options (i.e "* Using Google Translate")
+  NG_LOCALE_ALTERNATIVES_EXPLANATION: ''
+  #
   #
   # For demo-purpose only: A highly visible label to show instance name/version
   ENV_NAME: ''
@@ -64,7 +75,7 @@ env:
   # This Sentence will be followd by a link to the "Contact-URL" set below
   TXT_ERROR_MESSAGE: 'Reach out to us at: '
   # Provide a URL that has contact-information on it, or a `mailto:contact@example.org`-URL
-  TXT_ERROR_CONTACT_URL: 'https://github.com/${{ github.repository }}'
+  TXT_ERROR_CONTACT_URL: 'https://redcross.org.ua/en/contacts/'
   # Call to action on a link that will reload the current page
   TXT_ERROR_RETRY: 'Try again?'
   #
@@ -85,7 +96,7 @@ env:
     en,
   # The readable label(s) on the link to the region-page
   REGIONS_LABELS: >-
-    Ukrainian,
+    Українська,
     English,
   # The ID of the Google Sheet(s) that contains the content for the region
   REGIONS_SHEET_IDS: >-
@@ -163,6 +174,9 @@ jobs:
           GOOGLE_SHEETS_API_KEY: ${{ secrets.GOOGLE_SHEETS_API_KEY }}
           GOOGLE_SHEETS_API_URL: 'https://sheets.googleapis.com/v4/spreadsheets'
           AI_CONNECTION_STRING: ${{ secrets.AI_CONNECTION_STRING }}
+
+      - name: Add generic files
+        run: 'cp -r ./public/. www/'
 
       - name: Add 404.html
         run: 'cp www/index.html www/404.html'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains deployment details of a [Helpful Information App](https://github.com/rodekruis/helpful-information)-instance.
 
-Public URL: <https://redcrossorgua.github.io/hiapage/>
+Public URL: <https://help.redcross.org.ua/>
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
     "node": ">=22"
   },
   "dependencies": {
-    "helpful-information": "https://github.com/rodekruis/helpful-information/tarball/v24.06.1"
+    "helpful-information": "https://github.com/rodekruis/helpful-information/tarball/v24.07.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "private": true,
   "engines": {
-    "node": ">=22"
+    "node": "^22.5.1"
   },
   "dependencies": {
-    "helpful-information": "https://github.com/rodekruis/helpful-information/tarball/v24.07.0"
+    "helpful-information": "https://github.com/rodekruis/helpful-information/tarball/v24.07.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
     "node": ">=22"
   },
   "dependencies": {
-    "helpful-information": "https://github.com/rodekruis/helpful-information/tarball/v24.06.0"
+    "helpful-information": "https://github.com/rodekruis/helpful-information/tarball/v24.06.1"
   }
 }

--- a/public/files/README.md
+++ b/public/files/README.md
@@ -1,0 +1,4 @@
+# Public files
+
+> The contents of this folder will be visible on:  
+> `https://<hia-instance-url>/files/`


### PR DESCRIPTION
I've prepared the changes that are necessary to upgrade to the most recent version of HIA.

The contents of the sheets can remain the same and will continue to work as before.

**New features**
- The language-switcher will be visible on the home-page already; not only in each language's section.
- Any file added to the `public/files`-folder(i.e. `example.pdf`) in this repository will be visible on the website as: `https://<url-of-hia-instance>/files/example.pdf`.  
  This can be used for PDF-files or other documents and can then be linked to (using the full URL) from the Answer/Offer-content or (Sub-)Category-descriptions in the sheet(s).

---

When this PR is merged, the new version will be automatically deployed to the website.
Visitors' browsers that visited the website before will auto-reload the latest version at their next visit/page-load.